### PR TITLE
Update devcontainer to go v1.23

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1.22-bookworm
+FROM mcr.microsoft.com/devcontainers/go:1.23-bookworm
 
 RUN apt-get update && \
     echo "wireshark-common wireshark-common/install-setuid boolean true" | debconf-set-selections && \


### PR DESCRIPTION
Go v1.22 causes error on MacOS:

```
go generate ./ebpf
go: downloading github.com/cilium/ebpf v0.12.3
go: downloading golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
go: downloading golang.org/x/sys v0.14.1-0.20231108175955-e4099bfacb8c
# runtime
/usr/local/go/src/runtime/mbitmap_noallocheaders.go:53:2: mallocHeaderSize redeclared in this block
        /usr/local/go/src/runtime/mbitmap.go:71:2: other declaration of mallocHeaderSize
/usr/local/go/src/runtime/mbitmap_noallocheaders.go:54:2: minSizeForMallocHeader redeclared in this block
        /usr/local/go/src/runtime/mbitmap.go:101:2: other declaration of minSizeForMallocHeader
/usr/local/go/src/runtime/mbitmap_noallocheaders.go:60:6: heapBitsInSpan redeclared in this block
        /usr/local/go/src/runtime/mbitmap.go:112:6: other declaration of heapBitsInSpan
/usr/local/go/src/runtime/mbitmap_noallocheaders.go:243:6: bulkBarrierPreWrite redeclared in this block
        /usr/local/go/src/runtime/mbitmap.go:418:6: other declaration of bulkBarrierPreWrite
/usr/local/go/src/runtime/mbitmap_noallocheaders.go:316:6: bulkBarrierPreWriteSrcOnly redeclared in this block
        /usr/local/go/src/runtime/mbitmap.go:504:6: other declaration of bulkBarrierPreWriteSrcOnly
/usr/local/go/src/runtime/mbitmap_noallocheaders.go:695:6: heapSetType redeclared in this block
        /usr/local/go/src/runtime/mbitmap.go:705:6: other declaration of heapSetType
/usr/local/go/src/runtime/mbitmap_noallocheaders.go:704:6: getgcmask redeclared in this block
        /usr/local/go/src/runtime/mbitmap.go:1750:6: other declaration of getgcmask
/usr/local/go/src/runtime/mbitmap_noallocheaders.go:798:6: userArenaHeapBitsSetType redeclared in this block
        /usr/local/go/src/runtime/arena.go:553:6: other declaration of userArenaHeapBitsSetType
/usr/local/go/src/runtime/mbitmap_noallocheaders.go:891:6: typePointers redeclared in this block
        /usr/local/go/src/runtime/mbitmap.go:122:6: other declaration of typePointers
/usr/local/go/src/runtime/mbitmap_noallocheaders.go:936:6: heapBitsSlice redeclared in this block
        /usr/local/go/src/runtime/mbitmap.go:587:6: other declaration of heapBitsSlice
/usr/local/go/src/runtime/mbitmap_noallocheaders.go:936:6: too many errors
ebpf/gen.go:3: running "go": exit status 1
```

Presumably, go v1.23 fixes the problem